### PR TITLE
add \pdfnobuiltintounicode\font@name to \AddUniSubCmap

### DIFF
--- a/contrib/dhucs-cmap.sty
+++ b/contrib/dhucs-cmap.sty
@@ -11,10 +11,10 @@
 %% version 2006/05/20 or later.
 %%
 \ProvidesPackage{dhucs-cmap}
-  [2007/06/16 searchable PDF for dhucs upon pdftex]
+  [2021/03/01 searchable PDF for dhucs upon pdftex]
 
-\RequirePackage{ifpdf}
-\ifpdf\else\expandafter\endinput\fi
+\RequirePackage{iftex}
+\ifpdf\else\endinput\fi
 
 \newcommand*\AddUniSubCmap{%
   \ifdefined \now@jamo@printing
@@ -72,6 +72,7 @@
   \fi
   \pdffontattr\font@name{/ToUnicode
     \csname dhucs-cmap-\h@ngulpl@ne\endcsname\space 0 R}%
+  \ifdefined\pdfnobuiltintounicode \pdfnobuiltintounicode\font@name \fi
 }
 
 \newcommand*\jamo@dh@cmap[1]{%
@@ -81,6 +82,7 @@
   \fi
   \pdffontattr\font@name{/ToUnicode
     \csname dhucs-cmap-mid-#1\endcsname\space 0 R}%
+  \ifdefined\pdfnobuiltintounicode \pdfnobuiltintounicode\font@name \fi
 }
 
 \def\dhucs@define@newfont{\define@newfont\AddUniSubCmap\h@ngulpl@ne}

--- a/dhucs.sty
+++ b/dhucs.sty
@@ -40,7 +40,7 @@
 \ProvidesPackage{dhucs}
   [2012/11/08 v5.3.2  typesetting UTF-8 Korean documents]
 
-\ifx가가\else
+\ifx 가가\else
   \DeclareOption*{\PassOptionsToPackage\CurrentOption{kotexutf}}
   \ProcessOptions\relax
   \RequirePackage{kotexutf}

--- a/kotexutf.sty
+++ b/kotexutf.sty
@@ -34,6 +34,30 @@
 
 \input kotexutf-core
 
+% redefine MakeUppercase as we suppressed uccode/lccode in kotexutf-core
+\DeclareRobustCommand{\MakeUppercase}[1]{{%
+  % begin patch
+  \count@"A0 \loop
+    \ifnum\count@="B7 \else
+      \begingroup
+      \@tempcnta\count@ \advance\@tempcnta-"20
+      \lccode`\~\count@ \lccode`\!\@tempcnta
+      \lowercase{\endgroup
+        \expandafter\def\csname u8:\string^^c3\string~\endcsname{^^c3!}}%
+    \fi
+  \ifnum\count@<"BE \advance\count@\@ne \repeat
+  % end patch
+      \def\i{I}\def\j{J}%
+      \def\reserved@a##1##2{\let##1##2\reserved@a}%
+      \expandafter\reserved@a\@uclclist\reserved@b{\reserved@b\@gobble}%
+      \let\UTF@two@octets@noexpand\@empty
+      \let\UTF@three@octets@noexpand\@empty
+      \let\UTF@four@octets@noexpand\@empty
+      \protected@edef\reserved@a{\uppercase{#1}}%
+      \reserved@a
+   }}
+\protected@edef\MakeUppercase#1{\MakeUppercase{#1}}
+
 % modified from lucenc.def
 \DeclareFontEncoding{LUC}{}{}
 %\DeclareFontSubstitution{LUC}{utbt}{m}{n}


### PR DESCRIPTION
LaTeX 2021/05/01 will include '\pdfgentounicode=1' dumped in the format.
So, if not '\pdfnobuiltintounicode\font', '/Font' objects in the PDF file
would have two '/ToUnicode' entries for Type1 subfonts: one built-in by
engine, the other created by this package. The commit aims to preclude
this unhappy redundancy.