### PR TITLE
unprotecting utf8 tokens is not needed now

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2021-XX-XX  Dohyun Kim  <nomos at ktug org>
+
+	Version X.X.X
+
+	* kotexutf.sty: redefine \MakeUppercase;
+	protect non-ascii characters in VerbatimOut environment;
+	revert hyperref bookmark patch of v2.1.1.
+
+	* dhucs-cmap.sty: prevent redundant ToUnicode entry.
+
 2015-09-14  Dohyun Kim  <nomos at ktug org>
 
 	Version 2.1.2
@@ -9,7 +19,7 @@
 
 	Version 2.1.1
 
-	* kotexutf.sty: unprotect protected chars for hyperref solving the bug 
+	* kotexutf.sty: unprotect protected chars for hyperref solving the bug
 	reported at http://www.ktug.org/xe/index.php?document_srl=210907
 
 2015-04-19  Dohyun Kim  <nomos at ktug org>
@@ -34,13 +44,13 @@
 2013-11-07  Kangsoo Kim  <karnes at ktug org>
 
 	No version change
-	
+
 	* kotexdoc.tex: revised for new Xindy related matters
 
 2013-10-24  Kihwang Lee  <leekh at ktug org>
 
 	No version change
-	
+
 	* Uploaded to CTAN
 
 2013-10-22  Kangsoo Kim  <karnes at ktug org>
@@ -50,7 +60,7 @@
 2013-10-21  Kihwang Lee  <leekh at ktug org>
 
 	Version 2.0.0
-	
+
 	* kotex-utf packaging, uploaded to https://github.com/kihwanglee/kotex-utf
 
 2013-10-21  Kangsoo Kim  <karnes at ktug org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,8 @@
-2021-XX-XX  Dohyun Kim  <nomos at ktug org>
+2022-XX-XX  Dohyun Kim  <nomos at ktug org>
 
 	Version X.X.X
 
-	* kotexutf.sty: redefine \MakeUppercase;
+	* kotexutf.sty:
 	protect non-ascii characters in VerbatimOut environment;
 	revert hyperref bookmark patch of v2.1.1.
 

--- a/contrib/dhucs-trivcj.sty
+++ b/contrib/dhucs-trivcj.sty
@@ -16,7 +16,7 @@
   [2011/08/17 temporary chinese/japanese for dhucs]
 
 %%%%%% luatex & xetex
-\ifx가가\relax
+\ifx 가가\relax
   \newcommand*\trivcjtypesetting{%
     \parindent1em
     \let\nbs\nobreakspace %% see CJK.sty

--- a/kotexutf.sty
+++ b/kotexutf.sty
@@ -58,6 +58,13 @@
    }}
 \protected@edef\MakeUppercase#1{\MakeUppercase{#1}}
 
+% care about fancyvrb's VerbatimOut env
+\def\kotex@make@utfviii@other{%
+  \count@"80 \loop \catcode\count@=12 \ifnum\count@<"BF \advance\count@\@ne \repeat
+  \count@"C2 \loop \catcode\count@=12 \ifnum\count@<"F4 \advance\count@\@ne \repeat
+}
+\AddToHook{env/VerbatimOut/begin}{\kotex@make@utfviii@other}
+
 % modified from lucenc.def
 \DeclareFontEncoding{LUC}{}{}
 %\DeclareFontSubstitution{LUC}{utbt}{m}{n}

--- a/kotexutf.sty
+++ b/kotexutf.sty
@@ -535,9 +535,9 @@
 \unless\ifdefined\pdfstringdefPreHook
   \let\pdfstringdefPreHook\@empty\fi
 \g@addto@macro\pdfstringdefPreHook{%
-  \unihangul@unprotect@range{C2}{DF}{two}%
-  \unihangul@unprotect@range{E0}{EF}{three}%
-  \unihangul@unprotect@range{F0}{F4}{four}%
+%  \unihangul@unprotect@range{C2}{DF}{two}%
+%  \unihangul@unprotect@range{E0}{EF}{three}%
+%  \unihangul@unprotect@range{F0}{F4}{four}%
   \let\unihangulchar\HyPsd@unichar
   \let\makejosa\@secondoftwo
   \let\dotemph\@firstofone

--- a/kotexutf.sty
+++ b/kotexutf.sty
@@ -111,14 +111,10 @@
   \def\dhucs@temp@hanjafont {#2}%
 }
 
-\protected\edef\normalfont{%
-  \unexpanded{%
-    \let\dhucs@temp@hangulfont\dhucs@undefined
-    \let\dhucs@temp@hanjafont \dhucs@undefined
-  }%
-  \unexpanded\expandafter{\normalfont}%
+\AddToHook{normalfont}{%
+  \let\dhucs@temp@hangulfont\dhucs@undefined
+  \let\dhucs@temp@hanjafont \dhucs@undefined
 }
-\let\reset@font\normalfont
 
 %% now print out \unihangulchar
 \newcommand*\unihangulchar@@@{%

--- a/kotexutf.sty
+++ b/kotexutf.sty
@@ -1,6 +1,7 @@
 %% File `kotexutf.sty`
 %%
-%% Copyright (C) 2012-2013 Dohyun Kim <nomos at ktug org>
+%% Copyright (C) 2012-2022 Dohyun Kim <nomos at ktug org>
+%% Copyright (C) 2015-2022 Kangsoo Kim <karnes at ktug org>
 %%
 %% This work may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either version 1.3c
@@ -10,9 +11,9 @@
 %% and version 1.3c or later is part of all distributions of LaTeX
 %% version 2006/05/20 or later.
 %%
-\NeedsTeXFormat{LaTeX2e}
+\NeedsTeXFormat{LaTeX2e}[2022/06/01]
 \ProvidesPackage{kotexutf}
-  [2015/07/18 v2.1.1 typesetting UTF-8 Korean documents]
+  [2022/06/22 v2.2.0 typesetting UTF-8 Korean documents]
 
 \newif\if@nonfrench
 \newif\if@hangul
@@ -33,30 +34,6 @@
 \RequirePackage[utf8]{inputenc}
 
 \input kotexutf-core
-
-% redefine MakeUppercase as we suppressed uccode/lccode in kotexutf-core
-\DeclareRobustCommand{\MakeUppercase}[1]{{%
-  % begin patch
-  \count@"A0 \loop
-    \ifnum\count@="B7 \else
-      \begingroup
-      \@tempcnta\count@ \advance\@tempcnta-"20
-      \lccode`\~\count@ \lccode`\!\@tempcnta
-      \lowercase{\endgroup
-        \expandafter\def\csname u8:\string^^c3\string~\endcsname{^^c3!}}%
-    \fi
-  \ifnum\count@<"BE \advance\count@\@ne \repeat
-  % end patch
-      \def\i{I}\def\j{J}%
-      \def\reserved@a##1##2{\let##1##2\reserved@a}%
-      \expandafter\reserved@a\@uclclist\reserved@b{\reserved@b\@gobble}%
-      \let\UTF@two@octets@noexpand\@empty
-      \let\UTF@three@octets@noexpand\@empty
-      \let\UTF@four@octets@noexpand\@empty
-      \protected@edef\reserved@a{\uppercase{#1}}%
-      \reserved@a
-   }}
-\protected@edef\MakeUppercase#1{\MakeUppercase{#1}}
 
 % care about fancyvrb's VerbatimOut env
 \def\kotex@make@utfviii@other{%


### PR DESCRIPTION
UTF-8 을 구성하는 토큰들이 더 이상 protected 되어있지 않으므로 불필요하게 되었습니다.